### PR TITLE
Companion url in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Add the cdn stylesheet in index.html or download
             headers?: object // additional headers eg:Authorization Token
         },
         plugins?: {
+            companionUrl?: string // null | string - URL to a Companion instance.
             GoogleDrive?: boolean // null | boolean - Allow Uploading Photo From GoogleDrive
             Instagram?: boolean // null | boolean - Allow Uploading Photo From Instagram
             Webcam?: boolean // null | boolean - Allow Taking Photo From Webcam

--- a/projects/uppy-angular/src/lib/uppy-angular.component.ts
+++ b/projects/uppy-angular/src/lib/uppy-angular.component.ts
@@ -58,24 +58,24 @@ export class UppyAngularComponent implements OnInit {
 
 
     // Plugins
-
+    const companionUrl = this.config.plugins.companionUrl || 'https://companion.uppy.io';
     if (this.config.plugins.GoogleDrive) {
       const GoogleDrive = require('@uppy/google-drive')
-      uppy.use(GoogleDrive, { target: Dashboard, companionUrl: 'https://companion.uppy.io' })
+      uppy.use(GoogleDrive, { target: Dashboard, companionUrl: companionUrl })
     }
     if (this.config.plugins.Instagram) {
       const Instagram = require('@uppy/instagram')
-      uppy.use(Instagram, { target: Dashboard, companionUrl: 'https://companion.uppy.io' })
+      uppy.use(Instagram, { target: Dashboard, companionUrl: companionUrl })
     }
 
     if (this.config.plugins.Facebook) {
       const Facebook = require('@uppy/facebook')
-      uppy.use(Facebook, { target: Dashboard, companionUrl: 'https://companion.uppy.io' })
+      uppy.use(Facebook, { target: Dashboard, companionUrl: companionUrl })
     }
 
     if (this.config.plugins.Dropbox) {
       const Dropbox = require('@uppy/dropbox')
-      uppy.use(Dropbox, { target: Dashboard, companionUrl: 'https://companion.uppy.io' })
+      uppy.use(Dropbox, { target: Dashboard, companionUrl: companionUrl })
     }
 
     if (this.config.plugins.Webcam) {

--- a/projects/uppy-angular/src/lib/uppy-config.ts
+++ b/projects/uppy-angular/src/lib/uppy-config.ts
@@ -4,6 +4,7 @@ export interface UppyConfig {
         headers?: object // additional headers eg:Authorization Token
     },
     plugins?: {
+        companionUrl?: string // null | string - URL to a Companion instance.
         GoogleDrive?: boolean // null | boolean - Allow Uploading Photo From GoogleDrive
         Instagram?: boolean // null | boolean - Allow Uploading Photo From Instagram
         Webcam?: boolean // null | boolean - Allow Taking Photo From Webcam


### PR DESCRIPTION
It's really cool how easy it is to add a new provider to **uppy-angular,** but without your own _companion_ instance you won't be able to use google drive or facebook. This fix will make it possible :) 